### PR TITLE
各Worldのセーブをコンフィグで指定したTick間隔(デフォルト1Tick)で実行する機能を追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jp.minecraftuser</groupId>
     <artifactId>EcoAdmin</artifactId>
-    <version>1.10</version>
+    <version>1.11</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/jp/minecraftuser/ecoadmin/EcoAdmin.java
+++ b/src/main/java/jp/minecraftuser/ecoadmin/EcoAdmin.java
@@ -119,6 +119,7 @@ public class EcoAdmin  extends PluginFrame {
         conf.registerBoolean("util.auto_save.enable");
         conf.registerInt("util.auto_save.interval_tick");
         conf.registerInt("util.auto_save.start_mergin");
+        conf.registerInt("util.auto_save.delay_tick");
         conf.registerBoolean("util.auto_save.broadcast_information");
 
         // afk

--- a/src/main/java/jp/minecraftuser/ecoadmin/timer/SaveTimer.java
+++ b/src/main/java/jp/minecraftuser/ecoadmin/timer/SaveTimer.java
@@ -5,12 +5,15 @@ import jp.minecraftuser.ecoframework.TimerFrame;
 import static jp.minecraftuser.ecoframework.Utl.sendPluginMessage;
 import org.bukkit.World;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 /**
  * セーブタイマー
  * @author ecolight
  */
 public class SaveTimer extends TimerFrame {
-    private final boolean isBroadcast;
     /**
      * コンストラクタ
      * @param plg_ プラグインインスタンス
@@ -18,27 +21,86 @@ public class SaveTimer extends TimerFrame {
      */
     public SaveTimer(PluginFrame plg_, String name_) {
         super(plg_, name_);
-        isBroadcast = conf.getBoolean("util.auto_save.broadcast_information");
     }
 
     /**
      * 非同期処理メイン
      */
     @Override
-    public void run()
-    {
+    public void run() {
+
+        //非同期で処理するのでWorldリストではなくWorldUUIDのリストを作成
+        List<UUID> world_uuid_list = new ArrayList<UUID>();
+
+        for (World w : plg.getServer().getWorlds()) {
+            world_uuid_list.add(w.getUID());
+        }
+        //コンフィグで指定したTick間隔で各WorldをSaveする
+        new DelaySaveAllTimer(plg, name, world_uuid_list).runTaskTimer(plg, 1, conf.getInt("util.auto_save.delay_tick"));
+    }
+}
+
+/**
+ * コンフィグで指定したTick間隔で各WorldをSaveする
+ * @author ecolight
+ */
+class DelaySaveAllTimer extends TimerFrame {
+    int index = 0;
+    List<UUID> world_uuid_list;
+    private final boolean isBroadcast;
+
+    /**
+     * コンストラクタ
+     *
+     * @param plg_  プラグインインスタンス
+     * @param name_ 名前
+     */
+    public DelaySaveAllTimer(PluginFrame plg_, String name_, List<UUID> world_UUID_List) {
+        super(plg_, name_);
+        this.world_uuid_list = world_UUID_List;
+
+        isBroadcast = conf.getBoolean("util.auto_save.broadcast_information");
         if (isBroadcast) {
             sendPluginMessage(plg, null, "定期セーブを実行中(Auto saving...)");
         }
+        //Playerはコンストラクタ実行の時点でセーブする｡
         log.info("セーブ中[players]");
         plg.getServer().savePlayers();
-        for (World w : plg.getServer().getWorlds()) {
-            log.info("セーブ中[players]");
-            log.info("セーブ中[world:" + w.getName() + "]");
-            w.save();
-        }
-        if (isBroadcast) {
-            sendPluginMessage(plg, null, "定期セーブを完了しました(Auto save is complete.)");
+    }
+
+    /**
+     * 非同期処理メイン
+     */
+    @Override
+    public void run() {
+        if (index < world_uuid_list.size()) {
+            UUID world_uuid = world_uuid_list.get(index++);
+            World world = plg.getServer().getWorld(world_uuid);
+            //非同期で処理しているので一応nullチェック
+            if (world != null) {
+                log.info("セーブ中[world:" + world.getName() + "]");
+                world.save();
+            } else {
+                //Worldが存在しない場合
+                log.info("セーブ対象のWorld[" + world_uuid + "]が存在しません");
+            }
+
+            if (index < world_uuid_list.size()) {
+                //indexが最後の要素でなければセーブを続行する｡
+                return;
+            } else {
+                //indexが最後の要素なら全ワールドセーブ完了
+                if (isBroadcast) {
+                    sendPluginMessage(plg, null, "定期セーブを完了しました(Auto save is complete.)");
+                }
+                //Timerをキャンセルさせる
+                this.cancel();
+            }
+        } else {
+            //通常は通らない
+            log.info("WorldListが読み込まれていません｡");
+            //Timerをキャンセルさせる
+            this.cancel();
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,7 @@ util:
     enable: true
     interval_tick: 6000
     start_mergin: 6000
+    delay_tick: 1
     broadcast_information: true
   afk:
     enable: true


### PR DESCRIPTION
全ワールドセーブでサーバーが一瞬止まった際に､Player操作が巻き戻されるので
セーブを各ワールドごとにしてPlayer操作の巻き戻しを軽減(テスト実装)